### PR TITLE
Do not cache items if no conversion has been made

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: php
 
 php:
-  - "5.3"
   - "5.4"
   - "5.5"
   - "5.6"
   - "7.0"
+
+matrix:
+  include:
+    - php: "5.3"
+      dist: precise
 
 branches:
   only:

--- a/library/Barberry/Application.php
+++ b/library/Barberry/Application.php
@@ -44,7 +44,7 @@ class Application
 
     private function invokeCache(Response $response)
     {
-        if('GET' == strtoupper($_SERVER['REQUEST_METHOD'])) {
+        if('GET' == strtoupper($_SERVER['REQUEST_METHOD']) && $response->cacheable) {
             $this->resources->cache()->save($response->body, $this->resources->request());
         } elseif('DELETE' == strtoupper($_SERVER['REQUEST_METHOD'])) {
             $this->resources->cache()->invalidate($this->resources->request()->id);

--- a/library/Barberry/Response.php
+++ b/library/Barberry/Response.php
@@ -9,6 +9,7 @@ class Response {
     public $contentType;
     public $body;
     public $code;
+    public $cacheable;
 
     public static function notFound() {
         return new self(ContentType::json(), '{}', 404);
@@ -30,10 +31,11 @@ class Response {
         return new self(ContentType::json(), '{}', 500);
     }
 
-    public function __construct(ContentType $contentType, $body, $code = 200) {
+    public function __construct(ContentType $contentType, $body, $code = 200, $cacheable = true) {
         $this->contentType = $contentType;
         $this->body = $body;
         $this->code = $code;
+        $this->cacheable = $cacheable;
     }
 
     public function send() {

--- a/test/unit/ControllerTest.php
+++ b/test/unit/ControllerTest.php
@@ -105,10 +105,35 @@ class ControllerTest extends \PHPUnit_Framework_TestCase {
 
     public function testCanDetectOutputContentTypeByContentsOfStorage() {
         $this->assertEquals(
-            new Response(ContentType::txt(), '123'),
+            new Response(ContentType::txt(), '123', 200, false),
             self::c(
                 new Request('/11'),
                 m::mock('Barberry\\Storage\\StorageInterface', array('getById' => '123'))
+            )->GET()
+        );
+    }
+
+    public function testNotCacheableIfNullConverter() {
+        $this->assertEquals(
+            new Response(ContentType::txt(), '123', 200, false),
+            self::c(
+                new Request('/11.txt'),
+                m::mock('Barberry\\Storage\\StorageInterface', array('getById' => '123')),
+                m::mock('Barberry\\Direction\\Factory', array('direction' => new Plugin\NullPlugin))
+            )->GET()
+        );
+    }
+
+    public function testCacheableIfNotNullConverter() {
+        $this->assertEquals(
+            new Response(ContentType::txt(), '123', 200, true),
+            self::c(
+                new Request('/11.txt'),
+                null,
+                m::mock(
+                    'Barberry\\Direction\\Factory',
+                    array('direction' => m::mock('Barberry\\Plugin\\InterfaceConverter', array('convert' => '123')))
+                )
             )->GET()
         );
     }


### PR DESCRIPTION
For now we cache files even if they were not converted anyhow. In this case we're having duplicated files in storage and cache directories. That can be critical, if we have a lot of pdf files which we're fetching. Size, needed to store all this data will be doubled in worst case.

This fix checks for no changes made to file, and do not cache it in this case.