### PR TITLE
Recognize content type by temp filename, fix memory leaks 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "barberry/interfaces": "^2.0"
+        "barberry/interfaces": "dev-master"
     },
     "suggest": {
         "ext-openssl": "*"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "ext-json": "*",
         "php": "^5.6 || ^7.0",
-        "barberry/interfaces": "dev-master"
+        "barberry/interfaces": "^2.5"
     },
     "suggest": {
         "ext-openssl": "*"

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         ]
     },
     "require": {
+        "ext-json": "*",
         "php": "^5.6 || ^7.0",
         "barberry/interfaces": "dev-master"
     },
@@ -18,6 +19,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "mikey179/vfsstream": "^1.6"
     }
 }

--- a/library/Barberry/Controller.php
+++ b/library/Barberry/Controller.php
@@ -42,7 +42,7 @@ class Controller implements Controller\ControllerInterface {
         }
 
         try {
-            $contentType = ContentType::byString($this->request->bin);
+            $contentType = ContentType::byFilename($this->request->tmpName);
         } catch (ContentType\Exception $e) {
             throw new Controller\NotImplementedException($e->getMessage());
         }
@@ -52,7 +52,7 @@ class Controller implements Controller\ControllerInterface {
             json_encode(
                 array(
                     'id' => $this->storage->save($this->request->bin),
-                    'contentType' => strval($contentType),
+                    'contentType' => (string) $contentType,
                     'ext' => $contentType->standardExtension(),
                     'length' => strlen($this->request->bin),
                     'filename' => $this->request->postedFilename,

--- a/library/Barberry/Controller.php
+++ b/library/Barberry/Controller.php
@@ -1,6 +1,7 @@
 <?php
+
 namespace Barberry;
-use Barberry\Response;
+
 use Barberry\Storage;
 use Barberry\Direction;
 
@@ -66,6 +67,7 @@ class Controller implements Controller\ControllerInterface {
     /**
      * @return Response
      * @throws Controller\NotFoundException
+     * @throws ContentType\Exception
      */
     public function GET() {
         try {
@@ -74,15 +76,17 @@ class Controller implements Controller\ControllerInterface {
             throw new Controller\NotFoundException;
         }
 
+        $contentType = $this->storage->getContentTypeById($this->request->id);
+
         if (is_null($this->request->contentType)) {
-            $this->request->defineContentType(ContentType::byString($bin));
+            $this->request->defineContentType($contentType);
         }
 
         try {
             return self::response(
                 $this->request->contentType,
                 $this->directionFactory->direction(
-                    ContentType::byString($bin),
+                    $contentType,
                     $this->request->contentType,
                     $this->request->commandString
                 )->convert($bin)

--- a/library/Barberry/Controller.php
+++ b/library/Barberry/Controller.php
@@ -5,7 +5,8 @@ namespace Barberry;
 use Barberry\Storage;
 use Barberry\Direction;
 
-class Controller implements Controller\ControllerInterface {
+class Controller implements Controller\ControllerInterface
+{
     /**
      * @var Direction\Factory
      */
@@ -26,7 +27,8 @@ class Controller implements Controller\ControllerInterface {
      * @param Storage\StorageInterface $storage
      * @param Direction\Factory $directionFactory
      */
-    public function __construct(Request $request, Storage\StorageInterface $storage, Direction\Factory $directionFactory) {
+    public function __construct(Request $request, Storage\StorageInterface $storage, Direction\Factory $directionFactory)
+    {
         $this->request = $request;
         $this->storage = $storage;
         $this->directionFactory = $directionFactory;
@@ -37,7 +39,8 @@ class Controller implements Controller\ControllerInterface {
      * @throws Controller\NullPostException
      * @throws Controller\NotImplementedException
      */
-    public function POST() {
+    public function POST()
+    {
         if (!strlen($this->request->bin)) {
             throw new Controller\NullPostException;
         }
@@ -69,7 +72,8 @@ class Controller implements Controller\ControllerInterface {
      * @throws Controller\NotFoundException
      * @throws ContentType\Exception
      */
-    public function GET() {
+    public function GET()
+    {
         try {
             $bin = $this->storage->getById($this->request->id);
         } catch (Storage\NotFoundException $e) {
@@ -104,7 +108,8 @@ class Controller implements Controller\ControllerInterface {
      * @return Response
      * @throws Controller\NotFoundException
      */
-    public function DELETE() {
+    public function DELETE()
+    {
         try {
             $this->storage->delete($this->request->id);
         } catch (Storage\NotFoundException $e) {
@@ -113,13 +118,13 @@ class Controller implements Controller\ControllerInterface {
         return self::response(ContentType::json(), '{}');
     }
 
-    public function __call($name, $args) {
+    public function __call($name, $args)
+    {
         throw new Controller\NotFoundException;
     }
 
-//--------------------------------------------------------------------------------------------------
-
-    private static function response($contentType, $body, $code = 200) {
+    private static function response($contentType, $body, $code = 200)
+    {
         return new Response($contentType, $body, $code);
     }
 

--- a/library/Barberry/PostedFile.php
+++ b/library/Barberry/PostedFile.php
@@ -41,14 +41,4 @@ class PostedFile
         trigger_error('Undefined property via __get(): ' . $property, E_USER_NOTICE);
         return null;
     }
-
-    public function getStandardExtension()
-    {
-        if (is_null($this->standardExtension) && !is_null($this->_bin)) {
-            $this->standardExtension = ContentType::byString($this->_bin)->standardExtension();
-        }
-
-        return $this->standardExtension;
-    }
-
 }

--- a/library/Barberry/PostedFile.php
+++ b/library/Barberry/PostedFile.php
@@ -1,10 +1,10 @@
 <?php
 
 namespace Barberry;
-use Barberry\ContentType;
 
 /**
  * @property-read string $bin
+ * @property-read string $tmpName
  * @property-read string $filename
  * @property-read string $md5
  *
@@ -22,11 +22,13 @@ class PostedFile
 
     /**
      * @param string $bin
+     * @param string $tmpName
      * @param string $filename
      */
-    public function __construct($bin, $filename = null)
+    public function __construct($bin, $tmpName, $filename = null)
     {
         $this->_bin = $bin;
+        $this->_tmpName = $tmpName;
         $this->_filename = $filename;
         $this->_md5 = md5($bin);
     }

--- a/library/Barberry/PostedFile/Collection.php
+++ b/library/Barberry/PostedFile/Collection.php
@@ -149,6 +149,7 @@ class Collection implements \ArrayAccess, \Iterator
         if (is_array($spec)) {
             $this->specsIterator[$key] = new \Barberry\PostedFile(
                 $this->readTempFile($spec['tmp_name']),
+                $spec['tmp_name'],
                 $spec['name']
             );
         }

--- a/library/Barberry/Request.php
+++ b/library/Barberry/Request.php
@@ -8,6 +8,7 @@ use Barberry\ContentType;
  * @property-read null|ContentType $contentType
  * @property-read null|string $group
  * @property-read null|string $bin
+ * @property-read null|string $tmpName
  * @property-read null|string $postedFilename
  * @property-read null|string $postedMd5
  * @property-read null|string $commandString

--- a/library/Barberry/Request.php
+++ b/library/Barberry/Request.php
@@ -39,6 +39,11 @@ class Request {
     /**
      * @var null|string
      */
+    private $_tmpName;
+
+    /**
+     * @var null|string
+     */
     private $_postedFilename;
 
     /**
@@ -75,6 +80,7 @@ class Request {
     private function keepPost(PostedFile $postedFile = null) {
         if (!is_null($postedFile)) {
             $this->_bin = $postedFile->bin;
+            $this->_tmpName = $postedFile->tmpName;
             $this->_postedFilename = $postedFile->filename;
             $this->_postedMd5 = $postedFile->md5;
         }

--- a/library/Barberry/Storage/File.php
+++ b/library/Barberry/Storage/File.php
@@ -1,6 +1,7 @@
 <?php
 namespace Barberry\Storage;
 
+use Barberry\ContentType;
 use Barberry\fs;
 use Barberry\nonlinear;
 
@@ -32,6 +33,18 @@ class File implements StorageInterface {
         }
 
         return $content;
+    }
+
+    /**
+     * @param string $id
+     * @return ContentType
+     * @throws ContentType\Exception
+     */
+    public function getContentTypeById($id)
+    {
+        return ContentType::byFilename(
+            $this->filePathById($id)
+        );
     }
 
     /**

--- a/library/Barberry/Storage/StorageInterface.php
+++ b/library/Barberry/Storage/StorageInterface.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Barberry\Storage;
+
+use Barberry\ContentType;
 
 interface StorageInterface {
 
@@ -9,6 +12,13 @@ interface StorageInterface {
      * @throws NotFoundException
      */
     public function getById($id);
+
+    /**
+     * @param string $id
+     * @return ContentType
+     * @throws ContentType\Exception
+     */
+    public function getContentTypeById($id);
 
     /**
      * @param string $id

--- a/test/unit/ControllerTest.php
+++ b/test/unit/ControllerTest.php
@@ -145,6 +145,6 @@ class ControllerTest extends \PHPUnit_Framework_TestCase {
     }
 
     private static function binaryRequest() {
-        return new Request('/', new PostedFile('0101010111', 'File.txt'));
+        return new Request('/', new PostedFile('0101010111', '/tmp/aD6gsl', 'File.txt'));
     }
 }

--- a/test/unit/ControllerTest.php
+++ b/test/unit/ControllerTest.php
@@ -16,13 +16,12 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        self::$filesystem = vfsStream::setup();
-        vfsStream::create([
+        self::$filesystem = vfsStream::setup('root', null, [
             'tmp' => [
                 'aD6gsl' => "Column1\tColumn2\tColumn3",
                 'test.odt' => dechex(0)
             ]
-        ], self::$filesystem);
+        ]);
     }
 
     public function testDataType()

--- a/test/unit/ControllerTest.php
+++ b/test/unit/ControllerTest.php
@@ -32,10 +32,16 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function testGETReadsStorage()
     {
         $storage = $this->createMock('Barberry\\Storage\\StorageInterface');
-        $storage->expects($this->once())
-                ->method('getById')
-                ->willReturn(Test\Data::gif1x1())
-                ->with('123asd');
+        $storage
+            ->expects($this->once())
+            ->method('getById')
+            ->willReturn(Test\Data::gif1x1())
+            ->with('123asd');
+
+        $storage
+            ->expects($this->once())
+            ->method('getContentTypeById')
+            ->willReturn(ContentType::gif());
 
         self::controller(new Request('/123asd.gif'), $storage)->GET();
     }
@@ -145,7 +151,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
             new Response(ContentType::txt(), '123'),
             self::controller(
                 new Request('/11'),
-                m::mock('Barberry\\Storage\\StorageInterface', array('getById' => '123'))
+                m::mock('Barberry\\Storage\\StorageInterface', array('getById' => '123', 'getContentTypeById' => ContentType::txt()))
             )->GET()
         );
     }
@@ -173,7 +179,11 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
             $request ?: new Request('/1.gif'),
             $storage ?: m::mock(
                 'Barberry\\Storage\\StorageInterface',
-                array('getById' => Test\Data::gif1x1(), 'save' => null, 'delete' => null)
+                array(
+                    'getById' => Test\Data::gif1x1(),
+                    'getContentTypeById' => ContentType::jpeg(),
+                    'save' => null,'delete' => null
+                )
             ),
             $directionFactory ?: m::mock('Barberry\\Direction\\Factory', array('direction' => new Plugin\NullPlugin))
         );

--- a/test/unit/Filter/FilterCompositeTest.php
+++ b/test/unit/Filter/FilterCompositeTest.php
@@ -10,7 +10,7 @@ class FilterCompositeTest extends \PHPUnit_Framework_TestCase {
 
     public function testCallsAssignedFilter() {
         $files = new Collection();
-        $files['file'] = new \Barberry\PostedFile('test', 'test.txt');
+        $files['file'] = new \Barberry\PostedFile('test', '/tmp/asD6yhq', 'test.txt');
 
         $filterMock = $this->filterMock($files, array('vars'));
         $this->c($filterMock)->filter($files, array('vars'));
@@ -20,13 +20,13 @@ class FilterCompositeTest extends \PHPUnit_Framework_TestCase {
         $vars = array('vars');
 
         $files = new Collection();
-        $files['file'] = new \Barberry\PostedFile('test', 'test.txt');
+        $files['file'] = new \Barberry\PostedFile('test', '/tmp/asD6yhq', 'test.txt');
 
         $filter1 = $this->filterMock($files, $vars);
         $filter2 = $this->filterMock(
             $files, $vars,
             function ($files, $vars) {
-                $files['file'] = new \Barberry\PostedFile('dsdgdfg', 'test_name.txt');
+                $files['file'] = new \Barberry\PostedFile('dsdgdfg', '/tmp/asD6yhq', 'test_name.txt');
             }
         );
         $filter3 = $this->filterMock($files, $vars);

--- a/test/unit/PostedDataProcessorTest.php
+++ b/test/unit/PostedDataProcessorTest.php
@@ -13,7 +13,7 @@ class PostedDataProcessorTest extends \PHPUnit_Framework_TestCase {
             ->will(
                 $this->returnCallback(
                     function (\Barberry\PostedFile\Collection $files, $vars) {
-                        $files['file'] = new PostedFile('test content', 'test.txt');
+                        $files['file'] = new PostedFile('test content', '/tmp/asD6yhq', 'test.txt');
                     }
                 )
             );
@@ -35,8 +35,8 @@ class PostedDataProcessorTest extends \PHPUnit_Framework_TestCase {
                 $this->returnValue(
                     new PostedFile\Collection(
                         array(
-                            'file' => new PostedFile('some', 'Name of a file.txt'),
-                            'image' => new PostedFile(Test\Data::gif1x1(), 'test.gif')
+                            'file' => new PostedFile('some', '/tmp/asD6yhq', 'Name of a file.txt'),
+                            'image' => new PostedFile(Test\Data::gif1x1(), '/tmp/zAq8ugi', 'test.gif')
                         )
                     )
                 )

--- a/test/unit/PostedFile/CollectionTest.php
+++ b/test/unit/PostedFile/CollectionTest.php
@@ -41,14 +41,14 @@ class CollectionTest extends \PHPUnit_Framework_TestCase {
 
     public function testCanSetPostedFile() {
         $collection = $this->partiallyMockedCollection();
-        $collection['file'] = new \Barberry\PostedFile('ssdgsdfg', 'test.txt');
+        $collection['file'] = new \Barberry\PostedFile('ssdgsdfg', '/tmp/asD6yhq', 'test.txt');
 
         $this->assertEquals('test.txt', $collection['file']->filename);
     }
 
     public function testCanAddNewPostedFile() {
         $collection = $this->partiallyMockedCollection();
-        $collection['image'] = new \Barberry\PostedFile('ssdgsdfg', 'test.txt');
+        $collection['image'] = new \Barberry\PostedFile('ssdgsdfg', '/tmp/asD6yhq', 'test.txt');
 
         $collection->rewind();
         $collection->next();
@@ -58,7 +58,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase {
 
     public function testCanUnshiftPostedFileToTheBeginning() {
         $collection = $this->partiallyMockedCollection();
-        $collection->unshift('image', new \Barberry\PostedFile('ssdgsdfg', 'test.txt'));
+        $collection->unshift('image', new \Barberry\PostedFile('ssdgsdfg', '/tmp/asD6yhq', 'test.txt'));
 
         $collection->rewind();
         $this->assertEquals('test.txt', $collection->current()->filename);
@@ -103,7 +103,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testCanBeCreatedWithPostedFilesInConstructor() {
-        $collection = new Collection(array('file' => new \Barberry\PostedFile(Test\Data::gif1x1(), 'test.gif')));
+        $collection = new Collection(array('file' => new \Barberry\PostedFile(Test\Data::gif1x1(), '/tmp/asD6yhq', 'test.gif')));
         $this->assertEquals(Test\Data::gif1x1(), $collection['file']->bin);
     }
 

--- a/test/unit/PostedFileTest.php
+++ b/test/unit/PostedFileTest.php
@@ -3,21 +3,22 @@ namespace Barberry;
 
 class PostedFileTest extends \PHPUnit_Framework_TestCase {
 
-    public function testProvidesAccessToBinAndFilenameProperties() {
-        $postedFile = new PostedFile(Test\Data::gif1x1(), 'some filename');
+    public function testProvidesAccessToFileProperties() {
+        $postedFile = new PostedFile(Test\Data::gif1x1(), '/tmp/asD6yhq', 'some filename');
 
         $this->assertEquals(Test\Data::gif1x1(), $postedFile->bin);
+        $this->assertEquals('/tmp/asD6yhq', $postedFile->tmpName);
         $this->assertEquals('some filename', $postedFile->filename);
     }
 
     public function testReturnStandardExtension() {
-        $postedFile = new PostedFile(Test\Data::gif1x1(), 'some filename');
+        $postedFile = new PostedFile(Test\Data::gif1x1(), '/tmp/asD6yhq', 'some filename');
         $this->assertEquals('gif', $postedFile->getStandardExtension());
     }
 
     public function testCalculatesMd5HashOfContent()
     {
-        $postedFile = new PostedFile(Test\Data::gif1x1(), '');
+        $postedFile = new PostedFile(Test\Data::gif1x1(), '/tmp/asD6yhq', '');
 
         $this->assertSame('325472601571f31e1bf00674c368d335', $postedFile->md5);
     }

--- a/test/unit/PostedFileTest.php
+++ b/test/unit/PostedFileTest.php
@@ -1,19 +1,16 @@
 <?php
+
 namespace Barberry;
 
-class PostedFileTest extends \PHPUnit_Framework_TestCase {
-
-    public function testProvidesAccessToFileProperties() {
+class PostedFileTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProvidesAccessToFileProperties()
+    {
         $postedFile = new PostedFile(Test\Data::gif1x1(), '/tmp/asD6yhq', 'some filename');
 
         $this->assertEquals(Test\Data::gif1x1(), $postedFile->bin);
         $this->assertEquals('/tmp/asD6yhq', $postedFile->tmpName);
         $this->assertEquals('some filename', $postedFile->filename);
-    }
-
-    public function testReturnStandardExtension() {
-        $postedFile = new PostedFile(Test\Data::gif1x1(), '/tmp/asD6yhq', 'some filename');
-        $this->assertEquals('gif', $postedFile->getStandardExtension());
     }
 
     public function testCalculatesMd5HashOfContent()

--- a/test/unit/RequestTest.php
+++ b/test/unit/RequestTest.php
@@ -40,7 +40,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testProvidesAccessToPostedFile() {
-        $request = new Request('', new PostedFile('123', 'Text.txt'));
+        $request = new Request('', new PostedFile('123', '/tmp/asD6yhq', 'Text.txt'));
         $this->assertEquals('123', $request->bin);
         $this->assertEquals('Text.txt', $request->postedFilename);
         $this->assertEquals('202cb962ac59075b964b07152d234b70', $request->postedMd5);


### PR DESCRIPTION
With this MR:

- On POST() action, content type of the uploaded file will be recognized by $_FILES['tmp_name']
- On GET() action , content type of original file will be recognized by original cached filename

In both cases `ContentType::byFilenam()` will be used which internally call `finfo::file` method, instead of `finfo::buffer` (which has a memory leaks)