### PR TITLE
Not create directories, because filesystem does it automatically

### DIFF
--- a/library/Barberry/Cache.php
+++ b/library/Barberry/Cache.php
@@ -37,11 +37,6 @@ class Cache {
 
     private function writeToFilesystem($streamOrContent, $filePath): void
     {
-        $dir = dirname($filePath);
-        if (!$this->directoryExists($dir)) {
-            $this->filesystem->createDirectory($dir, ['visibility' => 'public']);
-        }
-
         if ($streamOrContent instanceof StreamInterface) {
             $resource = tmpfile();
             if ($resource === false) {

--- a/library/Barberry/Storage/File.php
+++ b/library/Barberry/Storage/File.php
@@ -59,8 +59,6 @@ class File implements StorageInterface
             $path = $this->filePathById($id);
         } while ($this->filesystem->fileExists($path));
 
-        $this->filesystem->createDirectory(dirname($path), ['visibility' => 'public']);
-
         $stream = $uploadedFile->getStream();
 
         $this->filesystem->writeStream($path, $stream->detach(), ['visibility' => 'public']);


### PR DESCRIPTION
Due to filesystem architecture - we don't need create directories explicitly 
https://flysystem.thephpleague.com/docs/architecture/